### PR TITLE
docs: remove license section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,3 @@ npm run dev
 3. Commit your changes (`git commit -m 'Add some AmazingFeature'`)
 4. Push to the branch (`git push origin feature/AmazingFeature`)
 5. Open a Pull Request
-
-## License
-
-This project is licensed under the MIT License - see the LICENSE file for details.


### PR DESCRIPTION
The license section was redundant as the LICENSE file already contains the necessary details. This change simplifies the README and avoids duplication.